### PR TITLE
Fix error: "," had no equivalent

### DIFF
--- a/bf_to_suslang.py
+++ b/bf_to_suslang.py
@@ -15,6 +15,6 @@ for char in input_string:
         output += "imposter "
     elif char == ".":
         output += "eject "
-    elif char == "<":
+    elif char == ",":
         output += "vote "
 print(output)


### PR DESCRIPTION
"<" was repeated in two clauses: "imposter" and "vote". This fix makes the converter follow the README specifications properly.